### PR TITLE
Handle empty highlight group name

### DIFF
--- a/autoload/glowshi_ft.vim
+++ b/autoload/glowshi_ft.vim
@@ -259,8 +259,12 @@ function! s:clear_cmdline()
     echo
 endfunction
 
+function! s:hlexists(name)
+    return strlen(a:name) > 0 && hlexists(a:name)
+endfunction
+
 function! glowshi_ft#highlight()
-    if hlexists(g:glowshi_ft_selected_hl_link)
+    if s:hlexists(g:glowshi_ft_selected_hl_link)
         execute 'highlight! link GlowshiFtSelected ' . g:glowshi_ft_selected_hl_link
     else
         execute 'highlight GlowshiFtSelected'
@@ -270,7 +274,7 @@ function! glowshi_ft#highlight()
 \             . ' guibg=' . g:glowshi_ft_selected_hl_guibg
     endif
 
-    if hlexists(g:glowshi_ft_candidates_hl_link)
+    if s:hlexists(g:glowshi_ft_candidates_hl_link)
         execute 'highlight! link GlowshiFtCandidates ' . g:glowshi_ft_candidates_hl_link
     else
         execute 'highlight GlowshiFtCandidates'


### PR DESCRIPTION
In my environment, `hlexists("")` somehow evaluates to `1`.
So, when `g:glowshi_ft_selected_hl_link` is empty, it produces following error:

```
Error detected while processing function glowshi_ft#gs_f..<SNR>208_glowshi_ft..<SNR>208_choose_pos..glowshi_ft#highlight:
line    2:
E412: Not enough arguments: ":highlight link GlowshiFtSelected"
```

I'm not sure if this is the case in all environments, so please ignore this if you think something's wrong in my environment.
